### PR TITLE
Add Optional Cancel

### DIFF
--- a/hedged_test.go
+++ b/hedged_test.go
@@ -24,7 +24,7 @@ func TestUpto(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	c := NewClient(10*time.Millisecond, upto, nil)
+	c := NewClient(10*time.Millisecond, upto, true, nil)
 	c.Do(req)
 
 	if gotRequests != upto {
@@ -47,7 +47,7 @@ func TestBestResponse(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	c := NewClient(10*time.Millisecond, 10, nil)
+	c := NewClient(10*time.Millisecond, 10, true, nil)
 
 	start := time.Now()
 	c.Do(req)


### PR DESCRIPTION
Hello! Thank you for this repo. We'd like to use it in a project I'm working on to interact with GCS, but under load it regularly gives one of two errors: "context canceled" or "unexpected EOF".

The change in this PR will allows us to use this library with the GCS client without issue. 

If you would like to test yourself the following code reproduces it easily:
```
func main() {
	ctx := context.Background()

	customTransport := http.DefaultTransport.(*http.Transport).Clone()
	transportOptions := []option.ClientOption{
		option.WithScopes(storage.ScopeReadWrite),
	}

	transport, err := google_http.NewTransport(ctx, customTransport, transportOptions...)
	if err != nil {
		panic(err)
	}

	transport = hedgedhttp.NewRoundTripper(500*time.Millisecond, 2, transport)

	storageClientOptions := []option.ClientOption{
		option.WithHTTPClient(&http.Client{
			Transport: transport,
		}),
		option.WithScopes(storage.ScopeReadWrite),
	}

	client, err := storage.NewClient(ctx, storageClientOptions...)
	if err != nil {
		panic(err)
	}

	bucket := client.Bucket("some gcs bucket")
	buffer := make([]byte, 1000000)

	for i := 0; i < 100; i++ {
		r, err := bucket.Object("some gcs object").NewReader(ctx)
		if err != nil {
			panic(err)
		}
		_, err = r.Read(buffer)
		if err != nil {
			panic(err)
		}
		fmt.Println(string(buffer))
		r.Close()
	}
}
```

This appears to be because when you read the http response body after the request is cancelled it will return "context cancelled" which the GCS client then propagates back to our code.  Here is an article with some discussion (search for "response.Body"):

https://medium.com/the-software-firehose/canceling-requests-in-go-using-context-b4b28a118da8

This is the line that's throwing the error in the GCS client:

https://github.com/googleapis/google-cloud-go/blob/storage/v1.15.0/storage/reader.go#L369