### PR TITLE
Fix context canceled error via manual cancelling

### DIFF
--- a/hedged.go
+++ b/hedged.go
@@ -63,14 +63,14 @@ func (ht *hedgedTransport) RoundTrip(req *http.Request) (*http.Response, error) 
 	cancelCh := make(chan func(), ht.upto)
 	defer func() {
 		// close all sent request asynchronous
-		go func() {
+		runInPool(func() {
 			// if we're here then there will be no more requests
 			got := atomic.LoadInt64(&waitingFor)
 			for i := int64(0); i < got; i++ {
 				c := <-cancelCh
 				c()
 			}
-		}()
+		})
 	}()
 
 	for sent := 0; len(errOverall.Errors) < ht.upto; sent++ {

--- a/hedged.go
+++ b/hedged.go
@@ -59,7 +59,7 @@ func (ht *hedgedTransport) RoundTrip(req *http.Request) (*http.Response, error) 
 	errorCh := make(chan error, ht.upto)
 
 	resultIdx := -1
-	cancels := make([]func(), ht.upto+1)
+	cancels := make([]func(), ht.upto)
 
 	defer func() {
 		runInPool(func() {

--- a/hedged.go
+++ b/hedged.go
@@ -61,15 +61,13 @@ func (ht *hedgedTransport) RoundTrip(req *http.Request) (*http.Response, error) 
 	resultIdx := -1
 	cancels := make([]func(), ht.upto)
 
-	defer func() {
-		runInPool(func() {
-			for i, cancel := range cancels {
-				if i != resultIdx && cancel != nil {
-					cancel()
-				}
+	defer runInPool(func() {
+		for i, cancel := range cancels {
+			if i != resultIdx && cancel != nil {
+				cancel()
 			}
-		})
-	}()
+		}
+	})
 
 	for sent := 0; len(errOverall.Errors) < ht.upto; sent++ {
 		if sent < ht.upto {

--- a/hedged_test.go
+++ b/hedged_test.go
@@ -111,7 +111,7 @@ func TestBestResponse(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	resp, err := NewClient(10*time.Millisecond, 5, nil).Do(req)
+	_, err = NewClient(10*time.Millisecond, 5, nil).Do(req)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/hedged_test.go
+++ b/hedged_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"math/rand"
 	"net/http"
 	"net/http/httptest"
 	"strings"


### PR DESCRIPTION
Signed-off-by: Oleg Kovalov <oleg@hey.com>

Idea is pretty simple - close what was failed manually. No fails for `go test -v -count=100 -run=TestHTTP2` (haven't added HTTP2 test 'cause would like to omit not so needed dependencies).

```go
import "golang.org/x/net/http2"

func TestHTTP2(t *testing.T) {
	req, err := http.NewRequest("GET", "https://www.google.com", http.NoBody)
	if err != nil {
		t.Fatal(err)
	}

	const upto = 2
	client := &http.Client{
		Transport: NewRoundTripper(10*time.Millisecond, upto, &http2.Transport{}),
	}

	resp, err := client.Do(req)
	if err != nil {
		t.Fatal(err)
	}

	time.Sleep(50 * time.Millisecond)

	_, err = io.ReadAll(resp.Body)
	if err != nil && err != io.EOF {
		t.Fatal(err)
	}
}
```