### PR TITLE
Fix benchmarks

### DIFF
--- a/hedged_bench_test.go
+++ b/hedged_bench_test.go
@@ -64,7 +64,7 @@ func BenchmarkHedgedRequest(b *testing.B) {
 			var errors = uint64(0)
 			var snapshot atomic.Value
 
-			hedgedTarget, metrics := hedgedhttp.NewRoundTripperWithInstrumentation(1*time.Microsecond, 10, target)
+			hedgedTarget, metrics := hedgedhttp.NewRoundTripperWithInstrumentation(10*time.Nanosecond, 10, target)
 			initialSnapshot := metrics.GetSnapshot()
 			snapshot.Store(&initialSnapshot)
 


### PR DESCRIPTION
 Previously timeout between hedged requests was much bigger than actual overhead of hedging mechanisms.