### PR TITLE
Breaking change: return error instead of panicking

### DIFF
--- a/examples_test.go
+++ b/examples_test.go
@@ -21,7 +21,10 @@ func ExampleHedgedClient() {
 	timeout := 10 * time.Millisecond
 	upto := 7
 	client := &http.Client{Timeout: time.Second}
-	hedged := hedgedhttp.NewClient(timeout, upto, client)
+	hedged, err := hedgedhttp.NewClient(timeout, upto, client)
+	if err != nil {
+		panic(err)
+	}
 
 	// will take `upto` requests, with a `timeout` delay between them
 	resp, err := hedged.Do(req)
@@ -43,7 +46,10 @@ func ExampleHedgedRoundTripper() {
 	timeout := 10 * time.Millisecond
 	upto := 7
 	transport := http.DefaultTransport
-	hedged, stats := hedgedhttp.NewRoundTripperAndStats(timeout, upto, transport)
+	hedged, stats, err := hedgedhttp.NewRoundTripperAndStats(timeout, upto, transport)
+	if err != nil {
+		panic(err)
+	}
 
 	// print stats periodically
 	go func() {
@@ -68,7 +74,10 @@ func ExampleInstrumented() {
 		Transport: http.DefaultTransport,
 	}
 
-	_ = hedgedhttp.NewRoundTripper(time.Millisecond, 3, transport)
+	_, err := hedgedhttp.NewRoundTripper(time.Millisecond, 3, transport)
+	if err != nil {
+		panic(err)
+	}
 }
 
 type InstrumentedTransport struct {
@@ -94,7 +103,10 @@ func ExampleRatelimit() {
 		Limiter:   &RandomRateLimiter{},
 	}
 
-	_ = hedgedhttp.NewRoundTripper(time.Millisecond, 3, transport)
+	_, err := hedgedhttp.NewRoundTripper(time.Millisecond, 3, transport)
+	if err != nil {
+		panic(err)
+	}
 }
 
 // by example https://pkg.go.dev/golang.org/x/time/rate
@@ -133,7 +145,10 @@ func ExampleMultiTransport() {
 		Hedged: &http.Transport{MaxIdleConns: 30}, // just an example
 	}
 
-	_ = hedgedhttp.NewRoundTripper(time.Millisecond, 3, transport)
+	_, err := hedgedhttp.NewRoundTripper(time.Millisecond, 3, transport)
+	if err != nil {
+		panic(err)
+	}
 }
 
 type MultiTransport struct {

--- a/hedged_bench_test.go
+++ b/hedged_bench_test.go
@@ -67,7 +67,11 @@ func BenchmarkHedgedRequest(b *testing.B) {
 			var errors = uint64(0)
 			var snapshot atomic.Value
 
-			hedgedTarget, metrics := hedgedhttp.NewRoundTripperAndStats(10*time.Nanosecond, 10, target)
+			hedgedTarget, metrics, err := hedgedhttp.NewRoundTripperAndStats(10*time.Nanosecond, 10, target)
+			if err != nil {
+				b.Fatalf("want nil, got %s", err)
+			}
+
 			initialSnapshot := metrics.Snapshot()
 			snapshot.Store(&initialSnapshot)
 


### PR DESCRIPTION
This library will no longer panic when a validation failed in the New functions. Instead they will return an error. Also updated README example.

Issue: GH-23

BREAKING CHANGE: The New* function signatures have changed by returning an error on input validation failure.