### PR TITLE
Update link to an open-access version of The Tail at Scale paper

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Hedged HTTP client which helps to reduce tail latency at scale.
 
 ## Rationale
 
-See paper [Tail at Scale](https://cacm.acm.org/magazines/2013/2/160173-the-tail-at-scale/fulltext) by Jeffrey Dean, Luiz André Barroso. In short: the client first sends one request, but then sends an additional request after a timeout if the previous hasn't returned an answer in the expected time. The client cancels remaining requests once the first result is received.
+See paper [Tail at Scale](https://www.barroso.org/publications/TheTailAtScale.pdf) by Jeffrey Dean, Luiz André Barroso. In short: the client first sends one request, but then sends an additional request after a timeout if the previous hasn't returned an answer in the expected time. The client cancels remaining requests once the first result is received.
 
 ## Acknowledge
 


### PR DESCRIPTION
This is what I see for the current link

<img width="732" alt="image" src="https://github.com/cristalhq/hedgedhttp/assets/373762/bcb29d06-c73b-4c45-9935-fa6503993535">