### PR TITLE
Implement limited per-second hedging

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Thanks to [Bohdan Storozhuk](https://github.com/storozhukbm) for the review and 
 * Optimized for speed.
 * Clean and tested code.
 * Supports `http.Client` and `http.RoundTripper`.
-* Dependency-free.
+* Supports rate-limiting.
 
 ## Install
 

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/cristalhq/hedgedhttp
 
 go 1.16
+
+require golang.org/x/time v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+golang.org/x/time v0.3.0 h1:rg5rLMjNzMS1RkNLzCG38eapWhnYLFYXDXj2gOlr8j4=
+golang.org/x/time v0.3.0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=


### PR DESCRIPTION
This PR is an upstreaming of an implementation we have within Grafana Labs.

We need to restrict the number of hedged requests on a per-process level, in order to prevent large bursts of hedged requests when we hit the upstream service's limits and all requests start to become slow.

I've imported a dependency, which I believe violates one of the features, but I believe in this case it is warranted and the dependency can be trusted (it's an experimental package from the Go team, and may be upstreamed into the stdlib later).

I still need to write docs for usage, but wanted to get your thoughts on this first.

Credit to @cyriltovena for the initial implementation.