### PR TITLE
Revert "Simplify API (#31)"

### DIFF
--- a/examples_test.go
+++ b/examples_test.go
@@ -21,7 +21,7 @@ func ExampleClient() {
 	timeout := 10 * time.Millisecond
 	upto := 7
 	client := &http.Client{Timeout: time.Second}
-	hedged, _, err := hedgedhttp.NewClient(timeout, upto, client)
+	hedged, err := hedgedhttp.NewClient(timeout, upto, client)
 	if err != nil {
 		panic(err)
 	}
@@ -48,7 +48,7 @@ func ExampleRoundTripper() {
 	timeout := 10 * time.Millisecond
 	upto := 7
 	transport := http.DefaultTransport
-	hedged, stats, err := hedgedhttp.NewRoundTripper(timeout, upto, transport)
+	hedged, stats, err := hedgedhttp.NewRoundTripperAndStats(timeout, upto, transport)
 	if err != nil {
 		panic(err)
 	}
@@ -78,7 +78,7 @@ func Example_instrumented() {
 		Transport: http.DefaultTransport,
 	}
 
-	_, _, err := hedgedhttp.NewRoundTripper(time.Millisecond, 3, transport)
+	_, err := hedgedhttp.NewRoundTripper(time.Millisecond, 3, transport)
 	if err != nil {
 		panic(err)
 	}
@@ -109,7 +109,7 @@ func Example_ratelimited() {
 		Limiter:   &RandomRateLimiter{},
 	}
 
-	_, _, err := hedgedhttp.NewRoundTripper(time.Millisecond, 3, transport)
+	_, err := hedgedhttp.NewRoundTripper(time.Millisecond, 3, transport)
 	if err != nil {
 		panic(err)
 	}
@@ -153,7 +153,7 @@ func ExampleMultiTransport() {
 		Hedged: &http.Transport{MaxIdleConns: 30}, // just an example
 	}
 
-	_, _, err := hedgedhttp.NewRoundTripper(time.Millisecond, 3, transport)
+	_, err := hedgedhttp.NewRoundTripper(time.Millisecond, 3, transport)
 	if err != nil {
 		panic(err)
 	}

--- a/hedged_bench_test.go
+++ b/hedged_bench_test.go
@@ -67,7 +67,7 @@ func BenchmarkHedgedRequest(b *testing.B) {
 			errors := uint64(0)
 			var snapshot atomic.Value
 
-			hedgedTarget, metrics, err := hedgedhttp.NewRoundTripper(10*time.Nanosecond, 10, target)
+			hedgedTarget, metrics, err := hedgedhttp.NewRoundTripperAndStats(10*time.Nanosecond, 10, target)
 			if err != nil {
 				b.Fatalf("want nil, got %s", err)
 			}

--- a/hedged_test.go
+++ b/hedged_test.go
@@ -17,22 +17,22 @@ import (
 )
 
 func TestValidateInput(t *testing.T) {
-	_, _, err := hedgedhttp.NewClient(-time.Second, 0, nil)
+	_, _, err := hedgedhttp.NewClientAndStats(-time.Second, 0, nil)
 	if err == nil {
 		t.Fatalf("want err, got nil")
 	}
 
-	_, _, err = hedgedhttp.NewClient(time.Second, -1, nil)
+	_, _, err = hedgedhttp.NewClientAndStats(time.Second, -1, nil)
 	if err == nil {
 		t.Fatalf("want err, got nil")
 	}
 
-	_, _, err = hedgedhttp.NewClient(time.Second, 0, nil)
+	_, _, err = hedgedhttp.NewClientAndStats(time.Second, 0, nil)
 	if err == nil {
 		t.Fatalf("want err, got nil")
 	}
 
-	_, _, err = hedgedhttp.NewRoundTripper(time.Second, 0, nil)
+	_, err = hedgedhttp.NewRoundTripper(time.Second, 0, nil)
 	if err == nil {
 		t.Fatalf("want err, got nil")
 	}
@@ -52,7 +52,7 @@ func TestUpto(t *testing.T) {
 	}
 
 	const upto = 7
-	client, _, err := hedgedhttp.NewClient(10*time.Millisecond, upto, nil)
+	client, err := hedgedhttp.NewClient(10*time.Millisecond, upto, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -82,7 +82,7 @@ func TestUptoWithInstrumentation(t *testing.T) {
 	}
 
 	const upto = 7
-	client, metrics, err := hedgedhttp.NewClient(10*time.Millisecond, upto, nil)
+	client, metrics, err := hedgedhttp.NewClientAndStats(10*time.Millisecond, upto, nil)
 	if err != nil {
 		t.Fatalf("want nil, got %s", err)
 	}
@@ -131,7 +131,7 @@ func TestNoTimeout(t *testing.T) {
 
 	const upto = 10
 
-	client, metrics, err := hedgedhttp.NewClient(0, upto, nil)
+	client, metrics, err := hedgedhttp.NewClientAndStats(0, upto, nil)
 	if err != nil {
 		t.Fatalf("want nil, got %s", err)
 	}
@@ -174,7 +174,7 @@ func TestFirstIsOK(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	client, metrics, err := hedgedhttp.NewClient(10*time.Millisecond, 10, nil)
+	client, metrics, err := hedgedhttp.NewClientAndStats(10*time.Millisecond, 10, nil)
 	if err != nil {
 		t.Fatalf("want nil, got %s", err)
 	}
@@ -223,7 +223,7 @@ func TestBestResponse(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	client, metrics, err := hedgedhttp.NewClient(10*time.Millisecond, 5, nil)
+	client, metrics, err := hedgedhttp.NewClientAndStats(10*time.Millisecond, 5, nil)
 	if err != nil {
 		t.Fatalf("want nil, got %s", err)
 	}
@@ -284,7 +284,7 @@ func TestGetSuccessEvenWithErrorsPresent(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	client, metrics, err := hedgedhttp.NewClient(10*time.Millisecond, int(upto), nil)
+	client, metrics, err := hedgedhttp.NewClientAndStats(10*time.Millisecond, int(upto), nil)
 	if err != nil {
 		t.Fatalf("want nil, got %s", err)
 	}
@@ -341,7 +341,7 @@ func TestGetFailureAfterAllRetries(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	client, metrics, err := hedgedhttp.NewClient(time.Millisecond, upto, nil)
+	client, metrics, err := hedgedhttp.NewClientAndStats(time.Millisecond, upto, nil)
 	if err != nil {
 		t.Fatalf("want nil, got %s", err)
 	}
@@ -396,7 +396,7 @@ func TestHangAllExceptLast(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	client, metrics, err := hedgedhttp.NewClient(10*time.Millisecond, upto, nil)
+	client, metrics, err := hedgedhttp.NewClientAndStats(10*time.Millisecond, upto, nil)
 	if err != nil {
 		t.Fatalf("want nil, got %s", err)
 	}
@@ -448,7 +448,7 @@ func TestCancelByClient(t *testing.T) {
 	}
 
 	upto := 5
-	client, metrics, err := hedgedhttp.NewClient(10*time.Millisecond, upto, nil)
+	client, metrics, err := hedgedhttp.NewClientAndStats(10*time.Millisecond, upto, nil)
 	if err != nil {
 		t.Fatalf("want nil, got %s", err)
 	}
@@ -502,7 +502,7 @@ func TestIsHedged(t *testing.T) {
 	}
 
 	const upto = 7
-	client, _, err := hedgedhttp.NewRoundTripper(10*time.Millisecond, upto, rt)
+	client, err := hedgedhttp.NewRoundTripper(10*time.Millisecond, upto, rt)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This reverts commit e49977858f20dbcbe553f8ac6cf65e2e736ac616.

I did a mistake by merging this PR too early. First step is to deprecate some declarations & provide alternatives (and update dependants like @grafana), seconds step is to remove these declarations.

So, fixing now.