### PR TITLE
Drop stats snapshot

### DIFF
--- a/hedged_bench_test.go
+++ b/hedged_bench_test.go
@@ -70,14 +70,14 @@ func BenchmarkHedgedRequest(b *testing.B) {
 			hedgedTarget, metrics, err := hedgedhttp.NewRoundTripperAndStats(10*time.Nanosecond, 10, target)
 			mustOk(b, err)
 
-			initialSnapshot := metrics.Snapshot()
+			initialSnapshot := metrics.ActualRoundTrips()
 			snapshot.Store(&initialSnapshot)
 
 			go func() {
 				ticker := time.NewTicker(1 * time.Millisecond)
 				defer ticker.Stop()
 				for range ticker.C {
-					currentSnapshot := metrics.Snapshot()
+					currentSnapshot := metrics.ActualRoundTrips()
 					snapshot.Store(&currentSnapshot)
 				}
 			}()
@@ -100,7 +100,7 @@ func BenchmarkHedgedRequest(b *testing.B) {
 			}
 			wg.Wait()
 			if rand.Float32() < 0.001 {
-				fmt.Printf("Snapshot: %+v\n", snapshot.Load())
+				b.Logf("Snapshot: %+v\n", snapshot.Load())
 			}
 		})
 	}

--- a/hedged_test.go
+++ b/hedged_test.go
@@ -217,13 +217,11 @@ func TestFirstIsOK(t *testing.T) {
 	body, err := io.ReadAll(resp.Body)
 	mustOk(t, err)
 	mustEqual(t, string(body), "ok")
-	wantEqualMetrics(t, metrics, hedgedhttp.StatsSnapshot{
-		RequestedRoundTrips:      1,
-		ActualRoundTrips:         1,
-		FailedRoundTrips:         0,
-		CanceledByUserRoundTrips: 0,
-		CanceledSubRequests:      0,
-	})
+	mustEqual(t, metrics.RequestedRoundTrips(), uint64(1))
+	mustEqual(t, metrics.ActualRoundTrips(), uint64(1))
+	mustEqual(t, metrics.FailedRoundTrips(), uint64(0))
+	mustEqual(t, metrics.CanceledByUserRoundTrips(), uint64(0))
+	mustEqual(t, metrics.CanceledSubRequests(), uint64(0))
 }
 
 func TestBestResponse(t *testing.T) {
@@ -489,21 +487,13 @@ func (t testRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 
 func wantZeroMetrics(tb testing.TB, metrics *hedgedhttp.Stats) {
 	tb.Helper()
-	wantEqualMetrics(tb, metrics, hedgedhttp.StatsSnapshot{})
-}
-
-func wantEqualMetrics(tb testing.TB, metrics *hedgedhttp.Stats, snapshot hedgedhttp.StatsSnapshot) {
-	tb.Helper()
-	if metrics == nil {
-		tb.Fatalf("Metrics object can't be nil")
-	}
-
-	mustEqual(tb, metrics.Snapshot(), snapshot)
-	mustEqual(tb, metrics.RequestedRoundTrips(), snapshot.RequestedRoundTrips)
-	mustEqual(tb, metrics.ActualRoundTrips(), snapshot.ActualRoundTrips)
-	mustEqual(tb, metrics.FailedRoundTrips(), snapshot.FailedRoundTrips)
-	mustEqual(tb, metrics.CanceledByUserRoundTrips(), snapshot.CanceledByUserRoundTrips)
-	mustEqual(tb, metrics.CanceledSubRequests(), snapshot.CanceledSubRequests)
+	mustEqual(tb, metrics.RequestedRoundTrips(), uint64(0))
+	mustEqual(tb, metrics.ActualRoundTrips(), uint64(0))
+	mustEqual(tb, metrics.FailedRoundTrips(), uint64(0))
+	mustEqual(tb, metrics.OriginalRequestWins(), uint64(0))
+	mustEqual(tb, metrics.HedgedRequestWins(), uint64(0))
+	mustEqual(tb, metrics.CanceledByUserRoundTrips(), uint64(0))
+	mustEqual(tb, metrics.CanceledSubRequests(), uint64(0))
 }
 
 func testServerURL(tb testing.TB, h func(http.ResponseWriter, *http.Request)) string {

--- a/stats.go
+++ b/stats.go
@@ -65,23 +65,3 @@ func (s *Stats) CanceledByUserRoundTrips() uint64 {
 func (s *Stats) CanceledSubRequests() uint64 {
 	return atomic.LoadUint64(&s.canceledSubRequests.count)
 }
-
-// StatsSnapshot is a snapshot of Stats.
-type StatsSnapshot struct {
-	RequestedRoundTrips      uint64 // count of requests that were requested by client
-	ActualRoundTrips         uint64 // count of requests that were actually sent
-	FailedRoundTrips         uint64 // count of requests that failed
-	CanceledByUserRoundTrips uint64 // count of requests that were canceled by user, using request context
-	CanceledSubRequests      uint64 // count of hedged sub-requests that were canceled by transport
-}
-
-// Snapshot of the stats.
-func (s *Stats) Snapshot() StatsSnapshot {
-	return StatsSnapshot{
-		RequestedRoundTrips:      s.RequestedRoundTrips(),
-		ActualRoundTrips:         s.ActualRoundTrips(),
-		FailedRoundTrips:         s.FailedRoundTrips(),
-		CanceledByUserRoundTrips: s.CanceledByUserRoundTrips(),
-		CanceledSubRequests:      s.CanceledSubRequests(),
-	}
-}


### PR DESCRIPTION
Remove struct that doesn't give big benefits. Calling method for each metrics is not a big deal.

TODO(@cristaloleg): update @grafana and other users usages (if any).