### PR TITLE
New client API

### DIFF
--- a/examples_test.go
+++ b/examples_test.go
@@ -15,7 +15,7 @@ import (
 
 func ExampleClient() {
 	ctx := context.Background()
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://google.com", http.NoBody)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://cristalhq.dev", http.NoBody)
 	if err != nil {
 		panic(err)
 	}
@@ -67,7 +67,7 @@ func Example_configNext() {
 
 func ExampleRoundTripper() {
 	ctx := context.Background()
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://google.com", http.NoBody)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://cristalhq.dev", http.NoBody)
 	if err != nil {
 		panic(err)
 	}

--- a/hedged.go
+++ b/hedged.go
@@ -158,10 +158,10 @@ func NewRoundTripperAndStats(timeout time.Duration, upto int, rt http.RoundTripp
 }
 
 type hedgedTransport struct {
-	next    NextFn
 	rt      http.RoundTripper
 	timeout time.Duration
 	upto    int
+	next    NextFn
 	metrics *Stats
 }
 

--- a/hedged.go
+++ b/hedged.go
@@ -36,7 +36,7 @@ type Config struct {
 	Next NextFn
 }
 
-// NextFn represents a function that is called for each HTTP request.
+// NextFn represents a function that is called for each HTTP request for retrieving hedging options.
 type NextFn func() (upto int, delay time.Duration)
 
 // New returns a new Client for the given config.
@@ -70,7 +70,7 @@ func New(cfg Config) (*Client, error) {
 	return c, nil
 }
 
-// Stats returns stastics for the given client, see [Stats] methods.
+// Stats returns statistics for the given client, see [Stats] methods.
 func (c *Client) Stats() *Stats {
 	return c.stats
 }

--- a/hedged.go
+++ b/hedged.go
@@ -172,6 +172,12 @@ func (ht *hedgedTransport) RoundTrip(req *http.Request) (*http.Response, error) 
 	if ht.next != nil {
 		upto, timeout = ht.next()
 	}
+
+	// no hedged requests, just a regular one.
+	if upto == 0 {
+		return ht.rt.RoundTrip(req)
+	}
+
 	errOverall := &MultiError{}
 	resultCh := make(chan indexedResp, upto)
 	errorCh := make(chan error, upto)

--- a/hedged_test.go
+++ b/hedged_test.go
@@ -15,8 +15,50 @@ import (
 	"github.com/cristalhq/hedgedhttp"
 )
 
+func TestClient(t *testing.T) {
+	const handlerSleep = 100 * time.Millisecond
+	url := testServerURL(t, func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(handlerSleep)
+	})
+
+	cfg := hedgedhttp.Config{
+		Transport: http.DefaultTransport,
+		Upto:      3,
+		Delay:     50 * time.Millisecond,
+		Next: func() (upto int, delay time.Duration) {
+			return 5, 10 * time.Millisecond
+		},
+	}
+	client, err := hedgedhttp.New(cfg)
+	mustOk(t, err)
+
+	start := time.Now()
+	resp, err := client.Do(newGetReq(url))
+	took := time.Since(start)
+	mustOk(t, err)
+	defer resp.Body.Close()
+	mustTrue(t, resp != nil)
+	mustEqual(t, resp.StatusCode, http.StatusOK)
+
+	stats := client.Stats()
+	mustEqual(t, stats.ActualRoundTrips(), uint64(5))
+	mustEqual(t, stats.OriginalRequestWins(), uint64(1))
+	mustTrue(t, took >= handlerSleep && took < (handlerSleep+10*time.Millisecond))
+}
+
 func TestValidateInput(t *testing.T) {
-	_, _, err := hedgedhttp.NewClientAndStats(-time.Second, 0, nil)
+	var err error
+	_, err = hedgedhttp.New(hedgedhttp.Config{
+		Delay: -time.Second,
+	})
+	mustFail(t, err)
+
+	_, err = hedgedhttp.New(hedgedhttp.Config{
+		Upto: -1,
+	})
+	mustFail(t, err)
+
+	_, _, err = hedgedhttp.NewClientAndStats(-time.Second, 0, nil)
 	mustFail(t, err)
 
 	_, _, err = hedgedhttp.NewClientAndStats(time.Second, -1, nil)

--- a/hedged_test.go
+++ b/hedged_test.go
@@ -22,10 +22,10 @@ func TestValidateInput(t *testing.T) {
 	_, _, err = hedgedhttp.NewClientAndStats(time.Second, -1, nil)
 	mustFail(t, err)
 
-	_, _, err = hedgedhttp.NewClientAndStats(time.Second, 0, nil)
+	_, _, err = hedgedhttp.NewClientAndStats(time.Second, -1, nil)
 	mustFail(t, err)
 
-	_, err = hedgedhttp.NewRoundTripper(time.Second, 0, nil)
+	_, err = hedgedhttp.NewRoundTripper(time.Second, -1, nil)
 	mustFail(t, err)
 }
 


### PR DESCRIPTION
Fixes #49 PTAL @GiedriusS 

Basically `hedgedhttp.Client` implements `http.RoundTripper` and so-called `Doer` which is a popular interface for `http.Client`. ~~The only unanswered question is a good name for `Foo`/`FooFn` :)~~ this callback is called `Next`.

Another change is that setting `Upto` to `0` means no hedged requests will be made, which can work like a switch.

In the future all old functions will be deprecated to have a smaller API surface.

CC: @dannykopping I think you are interested too.